### PR TITLE
Add Claude Code monitoring

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/claude_code_monitoring/session-start.sh\""
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/claude_code_monitoring/session-end.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "name": "repo-agent",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "mounts": [
+    "source=claude-code-monitoring,target=/home/vscode/.claude/metrics,type=volume"
+  ],
+  "postCreateCommand": "bash claude_code_monitoring/devcontainer-bootstrap.sh"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,7 @@ cython_debug/
 .vscode/
 launch.json
 test.py
+
+# Claude Code monitoring — regenerable / secret, never commit
+claude_code_monitoring/usage_dashboard.html
+claude_code_monitoring/.aws-credentials.json

--- a/claude_code_monitoring/build_dashboard.py
+++ b/claude_code_monitoring/build_dashboard.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = ["boto3"]
+# ///
+"""Regenerate usage_dashboard.html from session telemetry.
+
+Default source: ~/.claude/metrics/usage.jsonl (local).
+
+Set CC_MONITORING_SOURCE=s3 (or pass --source s3) to read all session objects
+from the S3 bucket configured in ~/.claude/metrics/monitoring.config.json.
+
+The local source needs no third-party deps, so `python3 build_dashboard.py`
+works. The S3 source needs boto3 — run it with `uv run --script
+build_dashboard.py --source s3` and uv provisions boto3 from the block above.
+
+Pricing (USD per 1M tokens) is read from the shared S3 bucket for s3/merge
+builds — key `pricing.json` at the bucket root (override with `pricing_key` in
+the config) — falling back to a local ~/.claude/metrics/pricing.json. A pure
+local build reads only the local file. This builder runs centrally, not in dev
+containers, which is why repos no longer carry a pricing file of their own.
+
+S3 reads (sessions + pricing) use a dedicated read-only credential at
+~/.claude/metrics/.aws-reader-credentials.json if present — created from a
+separate IAM user with GetObject/ListBucket and kept only on the build machine,
+so the shipping key distributed into every repo can stay write-only. Falls back
+to the repo-level shipping creds (walk-up from cwd) when no reader key exists.
+Format: {"aws_access_key_id": "...", "aws_secret_access_key": "..."}.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+METRICS = Path.home() / ".claude" / "metrics"
+LOG = METRICS / "usage.jsonl"
+PRICING = METRICS / "pricing.json"
+CONFIG = METRICS / "monitoring.config.json"
+HTML = Path(__file__).parent / "usage_dashboard.html"
+
+# Dedicated read-only credential for building the dashboard. Lives only on the
+# machine that builds the dashboard — NOT distributed into repos. This lets the
+# per-repo shipping key stay write-only (PutObject) while a separate IAM user
+# holds GetObject/ListBucket. If absent, we fall back to the repo-level shipping
+# creds (single-key setups still work).
+READER_CREDS = METRICS / ".aws-reader-credentials.json"
+
+# Bedrock users run Claude Code through application inference profiles, so their
+# `model` arrives as an opaque ARN (.../application-inference-profile/<id>) that
+# encodes neither the model nor the user. This map (profile id -> {model, name})
+# resolves both — the profile NAME typically carries the owner (e.g.
+# "opus-4-6-esteban"). Regenerate it from Bedrock with:
+#   aws bedrock list-inference-profiles --type-equals APPLICATION
+# (see the writer note in the repo). Absent -> ARNs are left as-is.
+BEDROCK_PROFILES = METRICS / "bedrock_profiles.json"
+_PROFILE_RE = re.compile(r"application-inference-profile/([a-z0-9]+)")
+
+KEEP = {
+    "session_id", "source", "model", "cwd",
+    "repo_root", "repo_remote", "onboarded",
+    "start_ts", "start_iso", "end_ts", "end_iso",
+    "duration_secs", "reason",
+    "input_tokens", "output_tokens",
+    "cache_creation_input_tokens", "cache_read_input_tokens",
+    "peak_context_tokens",
+    "account_email", "account_name", "org_name",
+    "inference_profile",
+}
+
+
+def _load_profiles() -> dict:
+    try:
+        data = json.loads(BEDROCK_PROFILES.read_text())
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+_PROFILES = _load_profiles()
+
+
+def resolve_model(model):
+    """Map a Bedrock inference-profile ARN to (real_model, profile_name). The
+    '[1m]' context suffix, if present on the ARN, is preserved so these group
+    with directly-reported models like 'claude-opus-4-8[1m]'. Non-ARN models
+    pass through unchanged."""
+    if not model:
+        return model, None
+    m = _PROFILE_RE.search(model)
+    if not m:
+        return model, None
+    info = _PROFILES.get(m.group(1))
+    if not info:
+        return model, None
+    resolved = info.get("model", model)
+    if model.rstrip().endswith("[1m]") and not resolved.endswith("[1m]"):
+        resolved += "[1m]"
+    return resolved, info.get("name")
+
+
+def project(obj: dict) -> dict:
+    row = {k: obj.get(k) for k in KEEP}
+    row["model"], row["inference_profile"] = resolve_model(row.get("model"))
+    return row
+
+
+def load_local() -> list[dict]:
+    if not LOG.exists():
+        return []
+    rows: list[dict] = []
+    with LOG.open() as f:
+        for i, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(project(json.loads(line)))
+            except json.JSONDecodeError as e:
+                print(f"warn: skipping local line {i}: {e}", file=sys.stderr)
+    return rows
+
+
+def _find_credentials(start: Path) -> dict | None:
+    """Walk up from `start` to the gitignored repo-level AWS credentials file
+    (<repo>/claude_code_monitoring/.aws-credentials.json). No ~/.aws fallback."""
+    for d in (start, *start.parents):
+        f = d / "claude_code_monitoring" / ".aws-credentials.json"
+        if f.is_file():
+            try:
+                data = json.loads(f.read_text())
+            except (OSError, json.JSONDecodeError):
+                return None
+            if data.get("aws_access_key_id") and data.get("aws_secret_access_key"):
+                return {"aws_access_key_id": data["aws_access_key_id"],
+                        "aws_secret_access_key": data["aws_secret_access_key"]}
+            return None
+    return None
+
+
+def _reader_credentials() -> dict | None:
+    """Credentials for READING the bucket. Prefer the dedicated read-only key at
+    READER_CREDS so the distributed shipping key never needs GetObject; fall back
+    to the repo-level shipping creds (walk-up from cwd) for single-key setups."""
+    if READER_CREDS.is_file():
+        try:
+            data = json.loads(READER_CREDS.read_text())
+        except (OSError, json.JSONDecodeError):
+            data = {}
+        if data.get("aws_access_key_id") and data.get("aws_secret_access_key"):
+            return {"aws_access_key_id": data["aws_access_key_id"],
+                    "aws_secret_access_key": data["aws_secret_access_key"]}
+    return _find_credentials(Path.cwd())
+
+
+def load_s3() -> list[dict]:
+    if not CONFIG.exists():
+        sys.exit(f"S3 source requested but {CONFIG} not found")
+    cfg = json.loads(CONFIG.read_text())
+    bucket = cfg.get("s3_bucket")
+    if not bucket:
+        sys.exit("S3 source requested but s3_bucket not set in config")
+    prefix = cfg.get("s3_prefix", "sessions").strip("/") + "/"
+
+    try:
+        import boto3
+    except ImportError:
+        sys.exit("S3 source requires boto3 — run via `uv run --script build_dashboard.py --source s3`")
+
+    # Read-only reader key if present, else the repo-level shipping creds. Never
+    # `aws configure` / the default chain.
+    creds = _reader_credentials()
+    if creds is None:
+        sys.exit("no credentials found — expected a read-only key at "
+                 f"{READER_CREDS} or a repo-level claude_code_monitoring/"
+                 ".aws-credentials.json")
+    s3 = boto3.session.Session(
+        aws_access_key_id=creds["aws_access_key_id"],
+        aws_secret_access_key=creds["aws_secret_access_key"],
+        region_name=cfg.get("aws_region") or None,
+    ).client("s3")
+
+    rows: list[dict] = []
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if not key.endswith(".json"):
+                continue
+            body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+            try:
+                rows.append(project(json.loads(body)))
+            except json.JSONDecodeError as e:
+                print(f"warn: skipping s3 key {key}: {e}", file=sys.stderr)
+    return rows
+
+
+def fetch_pricing_s3() -> dict | None:
+    """Load pricing from the shared S3 bucket (uploaded centrally — the canonical
+    copy). Key defaults to 'pricing.json' at the bucket root, overridable via
+    `pricing_key` in the config. Best-effort: returns None on any problem so the
+    caller can fall back to a local pricing file."""
+    if not CONFIG.exists():
+        return None
+    try:
+        cfg = json.loads(CONFIG.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    bucket = cfg.get("s3_bucket")
+    if not bucket:
+        return None
+    key = cfg.get("pricing_key", "pricing.json")
+    try:
+        import boto3
+        creds = _reader_credentials()
+        if creds is None:
+            return None
+        s3 = boto3.session.Session(
+            aws_access_key_id=creds["aws_access_key_id"],
+            aws_secret_access_key=creds["aws_secret_access_key"],
+            region_name=cfg.get("aws_region") or None,
+        ).client("s3")
+        body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+        return json.loads(body)
+    except Exception as e:  # noqa: BLE001 — fall back to local on any failure
+        print(f"warn: could not read s3://{bucket}/{key} ({type(e).__name__}); "
+              f"falling back to {PRICING}", file=sys.stderr)
+        return None
+
+
+def load_pricing(source: str) -> dict:
+    """Pricing now lives in S3. For s3/merge builds, read it from the bucket and
+    fall back to the local file; a pure-local build reads only the local file."""
+    local = json.loads(PRICING.read_text()) if PRICING.exists() else {}
+    if source == "local":
+        return local
+    remote = fetch_pricing_s3()
+    return remote if remote is not None else local
+
+
+def dedupe(rows: list[dict]) -> list[dict]:
+    seen: dict[str, dict] = {}
+    for r in rows:
+        sid = r.get("session_id")
+        if not sid:
+            continue
+        seen[sid] = r  # last write wins; S3 + local should agree on session_id keys
+    return list(seen.values())
+
+
+def replace_block(html: str, marker: str, new_value: str) -> str:
+    pattern = re.compile(rf"const {marker} = .*?;\s*//\s*<<{marker}_END>>", re.DOTALL)
+    if not pattern.search(html):
+        sys.exit(f"could not find '{marker}' block in dashboard")
+    return pattern.sub(f"const {marker} = {new_value}; // <<{marker}_END>>", html)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--source",
+        choices=("local", "s3", "merge"),
+        default=os.environ.get("CC_MONITORING_SOURCE", "local"),
+        help="Where to read session data from (default: local, or $CC_MONITORING_SOURCE)",
+    )
+    args = parser.parse_args()
+
+    if not HTML.exists():
+        sys.exit(f"dashboard not found: {HTML}")
+
+    if args.source == "local":
+        rows = load_local()
+    elif args.source == "s3":
+        rows = load_s3()
+    else:  # merge
+        rows = dedupe(load_local() + load_s3())
+
+    if not rows and args.source == "local":
+        sys.exit(f"log not found or empty: {LOG}")
+
+    data_js = ",\n  ".join(json.dumps(r, separators=(",", ":")) for r in rows)
+    data_value = f"[\n  {data_js}\n]" if rows else "[]"
+
+    pricing = load_pricing(args.source)
+    pricing_value = json.dumps(pricing, indent=2)
+
+    built_value = json.dumps(datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC"))
+
+    html = HTML.read_text()
+    html = replace_block(html, "DATA", data_value)
+    html = replace_block(html, "PRICING", pricing_value)
+    html = replace_block(html, "BUILT_AT", built_value)
+    HTML.write_text(html)
+    print(f"updated {HTML} with {len(rows)} sessions (source={args.source})")
+
+
+if __name__ == "__main__":
+    main()

--- a/claude_code_monitoring/devcontainer-bootstrap.sh
+++ b/claude_code_monitoring/devcontainer-bootstrap.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Claude Code monitoring — dev container bootstrap.
+#
+# Vendored into <repo>/claude_code_monitoring/ by the onboarding step, and meant
+# to run as a devcontainer "postCreateCommand". On every container (re)build it:
+#   1. no-ops unless this repo is actually onboarded for monitoring,
+#   2. seeds the machine-level hook scripts that the repo's committed
+#      .claude/settings.json points at ($HOME/.claude/hooks/) from the copies
+#      vendored alongside this script, and
+#   3. ensures $HOME/.claude/metrics/ exists (the volume mount point) so session
+#      logs persist outside the container.
+#
+# Idempotent and side-effect-light: hook scripts are refreshed every run (so
+# fixes propagate), session data is never clobbered. Never fails the build —
+# missing prerequisites are warnings, not errors. (Pricing isn't seeded here —
+# it lives in the shared S3 bucket and is only needed by the dashboard builder,
+# which runs centrally, not inside dev containers.)
+set -euo pipefail
+
+# This script lives at <repo>/claude_code_monitoring/ ; the repo root is its parent.
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+SETTINGS="$REPO_ROOT/.claude/settings.json"
+
+log() { printf '  [claude-monitoring] %s\n' "$1"; }
+
+# 1. Act only if this repo is onboarded — its settings.json must register one of
+#    the monitoring session hooks. Otherwise quietly do nothing.
+if [ ! -f "$SETTINGS" ] || ! grep -qE 'session-(start|end)\.sh' "$SETTINGS" 2>/dev/null; then
+  log "repo not onboarded for monitoring — nothing to seed"
+  exit 0
+fi
+
+HOOKS_DIR="$HOME/.claude/hooks"
+METRICS_DIR="$HOME/.claude/metrics"
+
+# A named-volume mount at ~/.claude/metrics lands root-owned when the container
+# runs as a non-root user — Docker creates the mountpoint (and its parent
+# ~/.claude) as root. That blocks this user from writing ANYWHERE under
+# ~/.claude: our hook seeding here, and even the Claude CLI installer
+# (`~/.claude/downloads`). Best-effort self-heal before we touch it.
+CLAUDE_DIR="$HOME/.claude"
+if [ -e "$CLAUDE_DIR" ] && [ ! -w "$CLAUDE_DIR" ]; then
+  if command -v sudo >/dev/null 2>&1; then
+    sudo chown -R "$(id -u):$(id -g)" "$CLAUDE_DIR" 2>/dev/null \
+      && log "fixed ownership of $CLAUDE_DIR (root-owned from the volume mount)" \
+      || log "WARNING: $CLAUDE_DIR is root-owned and 'sudo chown' failed — run the container as root or chown it in postCreateCommand"
+  else
+    log "WARNING: $CLAUDE_DIR is root-owned and 'sudo' is unavailable — set \"remoteUser\": \"root\" or chown it in postCreateCommand"
+  fi
+fi
+mkdir -p "$HOOKS_DIR" "$METRICS_DIR"
+
+# 2. Runtime prerequisites. Warn, don't fail — the image owner controls these.
+#    Shipping signs S3 requests with the Python stdlib (SigV4) — no uv, no boto3,
+#    nothing to install — so jq + python3 are all that's needed.
+command -v jq      >/dev/null 2>&1 || log "WARNING: 'jq' not found — session hooks need it (e.g. apt-get install -y jq)"
+command -v python3 >/dev/null 2>&1 || log "WARNING: 'python3' not found — S3 shipping needs it (stdlib only)"
+
+# 3. Seed hook scripts from the vendored copies. Always refresh: these are code,
+#    not data, so a fix in the repo propagates on the next container build.
+seeded=0
+for f in session-start.sh session-end.sh ship_session.py; do
+  if [ -f "$HERE/$f" ]; then
+    cp "$HERE/$f" "$HOOKS_DIR/$f"
+    chmod +x "$HOOKS_DIR/$f"
+    seeded=$((seeded + 1))
+  else
+    log "WARNING: vendored '$f' missing from $HERE — re-run onboarding to refresh it"
+  fi
+done
+
+# 4. Enable S3 shipping by default (fixed org bucket). Seed only if absent so a
+#    populated volume / local edits are never clobbered.
+if [ -f "$HERE/monitoring.config.example.json" ] && [ ! -f "$METRICS_DIR/monitoring.config.json" ]; then
+  cp "$HERE/monitoring.config.example.json" "$METRICS_DIR/monitoring.config.json"
+  log "S3 shipping enabled — config seeded from vendored example"
+fi
+
+# 5. Register the session hooks at the USER level (~/.claude/settings.json) so
+#    they fire no matter which directory Claude is launched from in this
+#    container. Project settings are only read from the launch dir, which
+#    silently disables monitoring when the workspace root is a parent of this
+#    repo (monorepos / multi-root workspaces — a common dev-container layout),
+#    and also means sessions run outside the repo go unrecorded. User-level
+#    hooks cover every session in the container. Idempotent: a hook is added
+#    only if its command isn't already registered. Double-firing (when both this
+#    and the repo's project settings match) is de-duped by the session-end
+#    ship-once guard.
+#    Done with jq (the hooks' core dependency — present wherever monitoring runs),
+#    NOT python3: some slim images ship a python3 missing parts of the stdlib
+#    (e.g. no `json`), which would silently skip this step.
+USER_SETTINGS="$HOME/.claude/settings.json"
+# Literal $HOME (single-quoted) — Claude expands it at hook time, matching the
+# committed project-settings template.
+SS_CMD='$HOME/.claude/hooks/session-start.sh'
+SE_CMD='$HOME/.claude/hooks/session-end.sh'
+MERGE_PROG='def has($ev;$c): [.hooks[$ev][]?.hooks[]?.command] | any(.==$c);
+(if has("SessionStart";$ss) then . else .hooks.SessionStart += [{matcher:"",hooks:[{type:"command",command:$ss}]}] end)
+| (if has("SessionEnd";$se) then . else .hooks.SessionEnd += [{matcher:"",hooks:[{type:"command",command:$se}]}] end)'
+if ! command -v jq >/dev/null 2>&1; then
+  log "WARNING: jq missing — can't register user-level hooks; monitoring will only"
+  log "         fire when Claude is launched from a dir whose .claude/settings.json has them"
+elif [ -s "$USER_SETTINGS" ] && ! jq -e . "$USER_SETTINGS" >/dev/null 2>&1; then
+  log "WARNING: $USER_SETTINGS exists but isn't valid JSON — leaving it untouched"
+else
+  base='{}'; [ -s "$USER_SETTINGS" ] && base="$(cat "$USER_SETTINGS")"
+  if merged="$(printf '%s' "$base" | jq --arg ss "$SS_CMD" --arg se "$SE_CMD" "$MERGE_PROG" 2>/dev/null)"; then
+    printf '%s\n' "$merged" > "$USER_SETTINGS"
+    log "registered session hooks in $USER_SETTINGS (fire from any launch dir)"
+  else
+    log "WARNING: couldn't update $USER_SETTINGS — monitoring may only fire from the repo dir"
+  fi
+fi
+
+# 6. Seed AWS creds to a machine-level path so the shipper resolves them no
+#    matter the session's cwd — the per-repo walk-up fails when Claude runs from
+#    a parent/sibling of this repo, or outside it entirely. Only when the repo
+#    carries the (gitignored) creds file, i.e. the working tree is mounted into
+#    the container; never overwrite an existing machine-level creds file.
+if [ -f "$HERE/.aws-credentials.json" ] && [ ! -f "$METRICS_DIR/.aws-credentials.json" ]; then
+  cp "$HERE/.aws-credentials.json" "$METRICS_DIR/.aws-credentials.json"
+  chmod 600 "$METRICS_DIR/.aws-credentials.json"
+  log "seeded AWS credentials to $METRICS_DIR (resolves from any launch dir)"
+fi
+
+# 6b. Mark this container as "log every session." The hooks normally apply a
+#     per-repo opt-in gate (a host privacy measure), but inside a dev container the
+#     whole environment is a dedicated onboarded workspace and devs launch Claude
+#     from the container root — so here we log all sessions. This flag is
+#     container-local ($HOME/.claude, not the metrics volume), so it never reaches
+#     the host where the gate still applies.
+: > "$CLAUDE_DIR/.monitor-all" 2>/dev/null \
+  && log "logging all sessions in this container (per-repo gate is host-only)" || true
+
+# 7. Sanity: is the metrics dir writable by this user? A named-volume mount can
+#    land root-owned when the container runs as a non-root user, which would make
+#    session logging silently fail.
+if ( : > "$METRICS_DIR/.write-test" ) 2>/dev/null; then
+  rm -f "$METRICS_DIR/.write-test"
+else
+  log "WARNING: $METRICS_DIR is not writable by '$(id -un)'. If this container runs"
+  log "         as a non-root user, add a chown to postCreateCommand or set"
+  log "         \"remoteUser\": \"root\" — otherwise session logs can't be written."
+fi
+
+log "ready — $seeded hook script(s) in $HOOKS_DIR, logs -> $METRICS_DIR"
+exit 0

--- a/claude_code_monitoring/monitoring.config.example.json
+++ b/claude_code_monitoring/monitoring.config.example.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Copy to ~/.claude/metrics/monitoring.config.json to enable S3 shipping. Bucket/region are fixed (the shared org bucket). AWS credentials are NOT here and NOT from `aws configure` — they live per-repo in <repo>/claude_code_monitoring/.aws-credentials.json (gitignored). Delete this file to disable shipping (local logging continues).",
+  "s3_bucket": "claude-code-monitoring",
+  "s3_prefix": "sessions",
+  "aws_region": "us-east-1"
+}

--- a/claude_code_monitoring/session-end.sh
+++ b/claude_code_monitoring/session-end.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# NB: no `-u`. A session hook must never hard-crash the user's session; with `set
+# -u` an unbound variable aborts before the ERR trap can exit 0 (which is exactly
+# how a stray `stat` quirk surfaced as "unbound variable" and broke SessionEnd).
+# Without it, an unset var just expands empty and the trap keeps us at exit 0.
+set -eo pipefail
+
+METRICS_DIR="${HOME}/.claude/metrics"
+SESSIONS_DIR="${METRICS_DIR}/sessions"
+USAGE_LOG="${METRICS_DIR}/usage.jsonl"
+mkdir -p "${SESSIONS_DIR}"
+
+# Never block shutdown — trap any unexpected failure and exit 0.
+trap 'exit 0' ERR
+
+INPUT="$(cat || true)"
+
+SESSION_ID="$(printf '%s' "${INPUT}" | jq -r '.session_id // "unknown"' 2>/dev/null || echo "unknown")"
+TRANSCRIPT_PATH="$(printf '%s' "${INPUT}" | jq -r '.transcript_path // ""' 2>/dev/null || echo "")"
+REASON="$(printf '%s' "${INPUT}" | jq -r '.reason // ""' 2>/dev/null || echo "")"
+END_TS="$(date -u +%s)"
+END_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+STATE_FILE="${SESSIONS_DIR}/${SESSION_ID}.json"
+
+# Opt-in gate (mirrors session-start's marker check): no state file means
+# session-start didn't record this session — it wasn't an onboarded repo, or
+# start never ran — so do nothing. This is what keeps a global user-level hook
+# strictly per-repo: non-onboarded / personal sessions are never logged or shipped.
+[[ -f "${STATE_FILE}" ]] || exit 0
+
+# Ship-once guard. SessionEnd can fire twice for one session when the hooks are
+# registered at BOTH the user level (~/.claude/settings.json, seeded by the
+# dev-container bootstrap so monitoring fires from any launch dir) and the
+# project level (the repo's committed .claude/settings.json) — e.g. Claude is
+# launched from the onboarded repo root inside a container. Claim the session
+# atomically (noclobber); the second invocation no-ops so we never
+# double-append to usage.jsonl or ship the same session twice.
+ENDED_MARKER="${SESSIONS_DIR}/${SESSION_ID}.ended"
+if ! ( set -o noclobber; : > "${ENDED_MARKER}" ) 2>/dev/null; then
+  exit 0
+fi
+
+if [[ -f "${STATE_FILE}" ]]; then
+  START_TS="$(jq -r '.start_ts // 0' "${STATE_FILE}" 2>/dev/null || echo 0)"
+  START_ISO="$(jq -r '.start_iso // "unknown"' "${STATE_FILE}" 2>/dev/null || echo "unknown")"
+  SOURCE="$(jq -r '.source // "unknown"' "${STATE_FILE}" 2>/dev/null || echo "unknown")"
+  MODEL="$(jq -r '.model // "unknown"' "${STATE_FILE}" 2>/dev/null || echo "unknown")"
+  CWD="$(jq -r '.cwd // "unknown"' "${STATE_FILE}" 2>/dev/null || echo "unknown")"
+else
+  START_TS=0
+  START_ISO="unknown"
+  SOURCE="unknown"
+  MODEL="unknown"
+  CWD="unknown"
+fi
+
+if [[ "${START_TS}" =~ ^[0-9]+$ ]] && [[ "${START_TS}" -gt 0 ]]; then
+  DURATION_SECS=$(( END_TS - START_TS ))
+else
+  DURATION_SECS=0
+fi
+
+# Repo attribution from cwd. With user-level hooks, sessions fire from anywhere —
+# inside the onboarded repo, a parent/super-repo, a sibling, or no repo at all.
+# cwd (the full launch path) is already recorded; additionally resolve the git
+# repo so each record says *which* repo it belongs to. `repo_root` is the git
+# top-level at cwd; `repo_remote` its origin (the canonical "which repo");
+# `onboarded` flags whether that repo carries the monitoring runtime. All
+# best-effort — they degrade to "unknown"/false outside a git repo.
+REPO_ROOT="unknown"
+REPO_REMOTE="unknown"
+ONBOARDED=false
+if [[ "${CWD}" != "unknown" && -d "${CWD}" ]] && command -v git >/dev/null 2>&1; then
+  REPO_ROOT="$(git -C "${CWD}" rev-parse --show-toplevel 2>/dev/null || echo unknown)"
+  if [[ "${REPO_ROOT}" != "unknown" ]]; then
+    REPO_REMOTE="$(git -C "${REPO_ROOT}" remote get-url origin 2>/dev/null || echo unknown)"
+    [[ -d "${REPO_ROOT}/claude_code_monitoring" ]] && ONBOARDED=true
+  fi
+fi
+
+# Account info — cached for 24h to avoid hitting the API on every session.
+ACCOUNT_EMAIL="unknown"
+ACCOUNT_UUID="unknown"
+ACCOUNT_NAME="unknown"
+ORG_NAME="unknown"
+ORG_UUID="unknown"
+ACCOUNT_CACHE="${METRICS_DIR}/account.json"
+ACCOUNT_TTL=86400  # 24h
+
+refresh_account=0
+if [[ ! -f "${ACCOUNT_CACHE}" ]]; then
+  refresh_account=1
+else
+  # Portable mtime. Try GNU/Linux `stat -c %Y` FIRST (most containers), then
+  # BSD/macOS `stat -f %m`. NB: on GNU, `-f` is --file-system (not a format), so
+  # `stat -f %m FILE` prints a "File: ..." dump instead of failing — so we must
+  # not lead with it. The numeric guard then makes sure no stray output can reach
+  # the arithmetic (which under `set -u` would abort the whole hook).
+  MTIME="$(stat -c %Y "${ACCOUNT_CACHE}" 2>/dev/null || stat -f %m "${ACCOUNT_CACHE}" 2>/dev/null || echo 0)"
+  case "${MTIME}" in ''|*[!0-9]*) MTIME=0 ;; esac
+  CACHE_AGE=$(( $(date -u +%s) - MTIME ))
+  [[ "${CACHE_AGE}" -gt "${ACCOUNT_TTL}" ]] && refresh_account=1
+fi
+
+# Account switch: the cache is keyed by age, not by token, so a re-login would
+# otherwise keep stamping the old email until the TTL expires. If the credentials
+# file is newer than the cached profile, force a refresh. Best-effort — covers
+# Linux / dev containers (the creds file); macOS uses the keychain.
+if [[ -f "${HOME}/.claude/.credentials.json" \
+      && "${HOME}/.claude/.credentials.json" -nt "${ACCOUNT_CACHE}" ]]; then
+  refresh_account=1
+fi
+
+if [[ "${refresh_account}" -eq 1 ]]; then
+  # Token for the account-profile lookup. macOS: the keychain. Linux (incl. dev
+  # containers): the keychain command doesn't exist, so fall back to Claude's
+  # credentials file — without this, account_email stays "unknown" on Linux and
+  # S3 keys read sessions/unknown/...
+  TOKEN="$(security find-generic-password -s 'Claude Code-credentials' -w 2>/dev/null \
+    | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null || echo '')"
+  if [[ -z "${TOKEN}" && -f "${HOME}/.claude/.credentials.json" ]]; then
+    TOKEN="$(jq -r '.claudeAiOauth.accessToken // empty' "${HOME}/.claude/.credentials.json" 2>/dev/null || echo '')"
+  fi
+  if [[ -n "${TOKEN}" ]]; then
+    curl -fsS --max-time 5 \
+      -H "Authorization: Bearer ${TOKEN}" \
+      -H "anthropic-beta: oauth-2025-04-20" \
+      "https://api.anthropic.com/api/oauth/profile" \
+      -o "${ACCOUNT_CACHE}.tmp" 2>/dev/null \
+      && mv "${ACCOUNT_CACHE}.tmp" "${ACCOUNT_CACHE}" \
+      || rm -f "${ACCOUNT_CACHE}.tmp" 2>/dev/null || true
+  fi
+fi
+
+if [[ -f "${ACCOUNT_CACHE}" ]]; then
+  ACCOUNT_EMAIL="$(jq -r '.account.email // "unknown"' "${ACCOUNT_CACHE}" 2>/dev/null || echo unknown)"
+  ACCOUNT_UUID="$(jq -r  '.account.uuid  // "unknown"' "${ACCOUNT_CACHE}" 2>/dev/null || echo unknown)"
+  ACCOUNT_NAME="$(jq -r  '.account.full_name // "unknown"' "${ACCOUNT_CACHE}" 2>/dev/null || echo unknown)"
+  ORG_NAME="$(jq -r      '.organization.name // "unknown"' "${ACCOUNT_CACHE}" 2>/dev/null || echo unknown)"
+  ORG_UUID="$(jq -r      '.organization.uuid // "unknown"' "${ACCOUNT_CACHE}" 2>/dev/null || echo unknown)"
+fi
+
+# Token totals — sum across assistant message.usage objects in the transcript JSONL.
+INPUT_TOKENS=0
+OUTPUT_TOKENS=0
+CACHE_CREATION_TOKENS=0
+CACHE_READ_TOKENS=0
+PEAK_CONTEXT_TOKENS=0
+
+if [[ -n "${TRANSCRIPT_PATH}" && -f "${TRANSCRIPT_PATH}" ]]; then
+  # peak_context_tokens = largest single-request prompt size (input +
+  # cache-create + cache-read for one turn). This is the context-window
+  # high-water mark, distinct from the summed token flow.
+  TOKEN_JSON="$(jq -s '
+    [ .[] | select(.message?.usage?) | .message.usage ]
+    | {
+        input_tokens:                (map(.input_tokens // 0) | add // 0),
+        output_tokens:               (map(.output_tokens // 0) | add // 0),
+        cache_creation_input_tokens: (map(.cache_creation_input_tokens // 0) | add // 0),
+        cache_read_input_tokens:     (map(.cache_read_input_tokens // 0) | add // 0),
+        peak_context_tokens:         (map((.input_tokens // 0) + (.cache_creation_input_tokens // 0) + (.cache_read_input_tokens // 0)) | max // 0)
+      }
+  ' "${TRANSCRIPT_PATH}" 2>/dev/null || echo '{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"peak_context_tokens":0}')"
+  INPUT_TOKENS="$(printf '%s' "${TOKEN_JSON}" | jq -r '.input_tokens')"
+  OUTPUT_TOKENS="$(printf '%s' "${TOKEN_JSON}" | jq -r '.output_tokens')"
+  CACHE_CREATION_TOKENS="$(printf '%s' "${TOKEN_JSON}" | jq -r '.cache_creation_input_tokens')"
+  CACHE_READ_TOKENS="$(printf '%s' "${TOKEN_JSON}" | jq -r '.cache_read_input_tokens')"
+  PEAK_CONTEXT_TOKENS="$(printf '%s' "${TOKEN_JSON}" | jq -r '.peak_context_tokens')"
+fi
+
+RECORD="$(jq -nc \
+  --arg session_id "${SESSION_ID}" \
+  --arg source "${SOURCE}" \
+  --arg model "${MODEL}" \
+  --arg cwd "${CWD}" \
+  --arg repo_root "${REPO_ROOT}" \
+  --arg repo_remote "${REPO_REMOTE}" \
+  --argjson onboarded "${ONBOARDED}" \
+  --arg start_iso "${START_ISO}" \
+  --arg end_iso "${END_ISO}" \
+  --arg reason "${REASON}" \
+  --arg transcript_path "${TRANSCRIPT_PATH}" \
+  --arg account_email "${ACCOUNT_EMAIL}" \
+  --arg account_uuid "${ACCOUNT_UUID}" \
+  --arg account_name "${ACCOUNT_NAME}" \
+  --arg org_name "${ORG_NAME}" \
+  --arg org_uuid "${ORG_UUID}" \
+  --argjson start_ts "${START_TS}" \
+  --argjson end_ts "${END_TS}" \
+  --argjson duration_secs "${DURATION_SECS}" \
+  --argjson input_tokens "${INPUT_TOKENS}" \
+  --argjson output_tokens "${OUTPUT_TOKENS}" \
+  --argjson cache_creation_input_tokens "${CACHE_CREATION_TOKENS}" \
+  --argjson cache_read_input_tokens "${CACHE_READ_TOKENS}" \
+  --argjson peak_context_tokens "${PEAK_CONTEXT_TOKENS}" \
+  '{session_id:$session_id, source:$source, model:$model, cwd:$cwd,
+    repo_root:$repo_root, repo_remote:$repo_remote, onboarded:$onboarded,
+    start_ts:$start_ts, start_iso:$start_iso, end_ts:$end_ts, end_iso:$end_iso,
+    duration_secs:$duration_secs, reason:$reason, transcript_path:$transcript_path,
+    account_email:$account_email, account_uuid:$account_uuid, account_name:$account_name,
+    org_name:$org_name, org_uuid:$org_uuid,
+    input_tokens:$input_tokens, output_tokens:$output_tokens,
+    cache_creation_input_tokens:$cache_creation_input_tokens,
+    cache_read_input_tokens:$cache_read_input_tokens,
+    peak_context_tokens:$peak_context_tokens}')"
+
+printf '%s\n' "${RECORD}" >> "${USAGE_LOG}" 2>/dev/null || true
+
+# Fire-and-forget S3 upload. No-op if ~/.claude/metrics/monitoring.config.json
+# is missing or has no s3_bucket configured. Detached so it never blocks shutdown.
+#
+# Prefer `uv run --script`: uv reads ship_session.py's inline dependency block
+# and provisions boto3 in its own cache (no global install). Fall back to a bare
+# python3 if uv isn't on PATH — the shipper then queues the record if boto3 is
+# absent and drains it on a later run.
+# Locate the shipper: prefer the copy vendored alongside this script (so the hook
+# works when it runs straight from the repo's claude_code_monitoring/ — no
+# dependency on ~/.claude/hooks being seeded by a dev-container bootstrap), then
+# fall back to the machine-level copy.
+_HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+SHIP_SCRIPT="${_HERE}/ship_session.py"
+[[ -f "${SHIP_SCRIPT}" ]] || SHIP_SCRIPT="${HOME}/.claude/hooks/ship_session.py"
+if [[ -f "${SHIP_SCRIPT}" ]]; then
+  if command -v uv >/dev/null 2>&1; then
+    ( uv run --script "${SHIP_SCRIPT}" "${RECORD}" \
+        >> "${METRICS_DIR}/.ship.log" 2>&1 < /dev/null ) &
+    disown 2>/dev/null || true
+  elif command -v python3 >/dev/null 2>&1; then
+    ( python3 "${SHIP_SCRIPT}" "${RECORD}" \
+        >> "${METRICS_DIR}/.ship.log" 2>&1 < /dev/null ) &
+    disown 2>/dev/null || true
+  fi
+fi
+
+rm -f "${STATE_FILE}" 2>/dev/null || true
+
+exit 0

--- a/claude_code_monitoring/session-start.sh
+++ b/claude_code_monitoring/session-start.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+METRICS_DIR="${HOME}/.claude/metrics"
+SESSIONS_DIR="${METRICS_DIR}/sessions"
+mkdir -p "${SESSIONS_DIR}"
+
+# Self-seed S3 shipping config from the vendored example if absent, so shipping
+# works even when no dev-container bootstrap ran (e.g. a gitignored/absent
+# devcontainer.json). Only fires when this script runs from the repo's vendored
+# claude_code_monitoring/ (which carries the example); the machine-level copy in
+# ~/.claude/hooks has no example next to it, so it no-ops there. Never clobbers.
+_HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [ -f "${_HERE}/monitoring.config.example.json" ] && [ ! -f "${METRICS_DIR}/monitoring.config.json" ]; then
+  cp "${_HERE}/monitoring.config.example.json" "${METRICS_DIR}/monitoring.config.json" 2>/dev/null || true
+fi
+
+# Opt-in gate. This script can run as a USER-LEVEL hook (~/.claude/settings.json,
+# installed once globally) that fires for EVERY Claude session — so we record a
+# session ONLY if it belongs to an onboarded repo, identified by a
+# claude_code_monitoring/ marker directory. Walk UP from the session cwd (launched
+# inside the repo), then scan a couple of levels DOWN (launched from a parent that
+# holds onboarded repos — the shared dev-container case). No marker in scope means
+# this isn't an opted-in repo, so we do nothing — a dev's personal/non-org work is
+# never logged. (This keeps a single global hook strictly per-repo.)
+onboarded_root() {
+  local d="$1" m
+  while [ -n "$d" ] && [ "$d" != "/" ] && [ "$d" != "." ]; do
+    if [ -d "$d/claude_code_monitoring" ]; then printf '%s' "$d"; return 0; fi
+    d="$(dirname "$d")"
+  done
+  m="$(find "$1" -maxdepth 2 -type d -name claude_code_monitoring 2>/dev/null | head -n1 || true)"
+  if [ -n "$m" ]; then dirname "$m"; return 0; fi
+  return 1
+}
+
+INPUT="$(cat)"
+
+SESSION_ID="$(printf '%s' "${INPUT}" | jq -r '.session_id // "unknown"')"
+SOURCE="$(printf '%s' "${INPUT}" | jq -r '.source // "unknown"')"
+MODEL="$(printf '%s' "${INPUT}" | jq -r '.model // .model_id // "unknown"')"
+CWD="$(printf '%s' "${INPUT}" | jq -r '.cwd // "unknown"')"
+
+# In a dev container set up by our bootstrap, log EVERY session — the whole
+# container is a dedicated onboarded workspace and devs launch Claude from the
+# container root, not a repo root. The bootstrap drops this flag (container-local,
+# never on the host). Everywhere else (the host) apply the per-repo opt-in gate so
+# a dev's personal / non-org work is never logged.
+if [ ! -f "${HOME}/.claude/.monitor-all" ]; then
+  GATE_DIR="${CWD}"; [ "${GATE_DIR}" = "unknown" ] && GATE_DIR="${PWD}"
+  onboarded_root "${GATE_DIR}" >/dev/null 2>&1 || exit 0   # not an onboarded repo — no-op
+fi
+
+START_TS="$(date -u +%s)"
+START_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+STATE_FILE="${SESSIONS_DIR}/${SESSION_ID}.json"
+
+jq -n \
+  --arg session_id "${SESSION_ID}" \
+  --arg source "${SOURCE}" \
+  --arg model "${MODEL}" \
+  --arg cwd "${CWD}" \
+  --arg start_iso "${START_ISO}" \
+  --argjson start_ts "${START_TS}" \
+  '{session_id: $session_id, source: $source, model: $model, cwd: $cwd, start_ts: $start_ts, start_iso: $start_iso}' \
+  > "${STATE_FILE}"
+
+exit 0

--- a/claude_code_monitoring/ship_session.py
+++ b/claude_code_monitoring/ship_session.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = ["boto3"]
+# ///
+"""Async S3 uploader for Claude Code session telemetry.
+
+**No third-party dependencies required.** If boto3 is importable (e.g. run via
+`uv run --script`, which provisions it from the inline block above) it's used;
+otherwise the S3 PutObject is signed with AWS Signature V4 using only the Python
+standard library (hmac/hashlib/urllib). So a bare `python3` ships successfully —
+no `uv`, no boto3, nothing for a developer to install — which means the retry
+queue actually drains instead of waiting forever for a dependency that never
+arrives.
+
+Reads ~/.claude/metrics/monitoring.config.json for the bucket/prefix/region. If
+no s3_bucket is configured, exits 0. Otherwise:
+
+1. Drains the retry queue (~/.claude/metrics/.retry_queue.jsonl)
+2. Ships the JSON record passed on argv[1] (or stdin if no argv)
+
+AWS credentials are NOT taken from the default chain / `aws configure` / ~/.aws.
+They live per-repo in a gitignored file:
+    <repo>/claude_code_monitoring/.aws-credentials.json
+    {"aws_access_key_id": "...", "aws_secret_access_key": "..."}
+Each session record carries its repo `cwd`; the shipper walks up from there to
+find that file and passes the keys to boto3 explicitly. A record with no
+resolvable credentials file is left queued (and drains once creds are added).
+
+Each session is uploaded to:
+    s3://<bucket>/<prefix>/<account_email>/<end_iso>_<session_id>.json
+
+Idempotent: re-shipping the same session_id overwrites the same key.
+
+Failures are appended to the retry queue and drained on the next invocation.
+Never raises — exit code is always 0 so this can't break the session-end hook.
+"""
+from __future__ import annotations
+
+import contextlib
+import datetime
+import fcntl
+import hashlib
+import hmac
+import json
+import os
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+# boto3 is OPTIONAL: if it's importable (e.g. run via `uv run --script`) we use
+# it; otherwise we sign the S3 request ourselves with stdlib (SigV4) so shipping
+# works on a bare python3 — no uv, no boto3, nothing for a developer to install.
+try:
+    import boto3 as _BOTO3
+except Exception:  # noqa: BLE001
+    _BOTO3 = None
+
+METRICS = Path.home() / ".claude" / "metrics"
+CONFIG = METRICS / "monitoring.config.json"
+RETRY_QUEUE = METRICS / ".retry_queue.jsonl"
+SHIP_LOG = METRICS / ".ship.log"
+
+# Per-repo, gitignored credentials file (relative to a repo root). Resolved by
+# walking up from each session record's `cwd` — never from ~/.aws.
+CREDS_RELPATH = Path("claude_code_monitoring") / ".aws-credentials.json"
+
+# Machine-level fallback, seeded by the dev-container bootstrap. Used when the
+# walk-up from `cwd` can't reach a repo creds file — e.g. Claude is launched from
+# a parent of the onboarded repo (monorepo / multi-root workspace), so the
+# session's cwd is above (or beside) the repo that holds the per-repo creds.
+METRICS_CREDS = METRICS / ".aws-credentials.json"
+
+
+
+def log(msg: str) -> None:
+    SHIP_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with SHIP_LOG.open("a") as f:
+        f.write(f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {msg}\n")
+
+
+def load_config() -> dict | None:
+    if not CONFIG.exists():
+        return None
+    try:
+        cfg = json.loads(CONFIG.read_text())
+    except json.JSONDecodeError as e:
+        log(f"config parse error: {e}")
+        return None
+    if not cfg.get("s3_bucket"):
+        return None
+    return cfg
+
+
+def _read_creds(f: Path) -> dict | None:
+    try:
+        data = json.loads(f.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        log(f"credentials parse error at {f}: {e}")
+        return None
+    ak = data.get("aws_access_key_id")
+    sk = data.get("aws_secret_access_key")
+    if ak and sk:
+        return {"aws_access_key_id": ak, "aws_secret_access_key": sk}
+    log(f"credentials file missing keys: {f}")
+    return None
+
+
+def find_credentials(cwd) -> dict | None:
+    """Resolve a session's AWS credentials. Tries, in order:
+
+    1. Walk up from the session's `cwd` to a repo-level
+       claude_code_monitoring/.aws-credentials.json (the per-repo creds).
+    2. The machine-level fallback (~/.claude/metrics/.aws-credentials.json),
+       seeded by the dev-container bootstrap — this is what lets sessions run
+       from a parent of the repo, a sibling dir, or entirely outside any
+       onboarded project still ship.
+
+    Deliberately never falls back to the default AWS chain / `aws configure`.
+    Returns {aws_access_key_id, aws_secret_access_key} or None.
+    """
+    if cwd:
+        try:
+            start = Path(cwd)
+        except (TypeError, ValueError):
+            start = None
+        if start is not None:
+            for d in (start, *start.parents):
+                f = d / CREDS_RELPATH
+                if f.is_file():
+                    creds = _read_creds(f)
+                    if creds:
+                        return creds
+                    break  # found but unusable — try the machine-level fallback
+    if METRICS_CREDS.is_file():
+        return _read_creds(METRICS_CREDS)
+    return None
+
+
+def ship_record(bucket: str, prefix: str, region, record: dict, raw: str) -> bool:
+    """Upload one record using its repo-level credentials. Returns True on success.
+    A record whose creds can't be resolved is treated as a (retryable) failure."""
+    creds = find_credentials(record.get("cwd"))
+    if creds is None:
+        log(f"no repo credentials for cwd={record.get('cwd')!r}; "
+            f"queueing session {record.get('session_id')}")
+        return False
+    return _put(bucket, region, build_key(prefix, record), raw.encode("utf-8"), creds)
+
+
+def build_key(prefix: str, record: dict) -> str:
+    email = record.get("account_email") or "unknown"
+    session_id = record.get("session_id") or "unknown"
+    end_iso = record.get("end_iso") or "unknown"
+    safe_email = email.replace("/", "_")
+    safe_id = session_id.replace("/", "_")
+    safe_iso = end_iso.replace(":", "").replace("/", "_")
+    prefix = prefix.strip("/")
+    return f"{prefix}/{safe_email}/{safe_iso}_{safe_id}.json"
+
+
+def _put(bucket: str, region, key: str, body: bytes, creds: dict) -> bool:
+    """Upload one object. Uses boto3 if available, else a stdlib SigV4 PUT."""
+    if _BOTO3 is not None:
+        try:
+            _BOTO3.session.Session(
+                aws_access_key_id=creds["aws_access_key_id"],
+                aws_secret_access_key=creds["aws_secret_access_key"],
+                region_name=region or None,
+            ).client("s3").put_object(
+                Bucket=bucket, Key=key, Body=body, ContentType="application/json")
+            return True
+        except Exception as e:  # noqa: BLE001
+            log(f"put (boto3) failed key={key}: {type(e).__name__}: {e}")
+            return False
+    try:
+        return _sigv4_put(bucket, region or "us-east-1", key, body, creds)
+    except urllib.error.HTTPError as e:  # noqa: BLE001
+        detail = ""
+        try:
+            detail = e.read()[:300].decode("utf-8", "replace")
+        except Exception:  # noqa: BLE001
+            pass
+        log(f"put (sigv4) HTTP {e.code} key={key}: {detail}")
+        return False
+    except Exception as e:  # noqa: BLE001 — network/SSL/etc — retryable
+        log(f"put (sigv4) failed key={key}: {type(e).__name__}: {e}")
+        return False
+
+
+def _sigv4_put(bucket: str, region: str, key: str, body: bytes, creds: dict) -> bool:
+    """S3 PutObject signed with AWS Signature V4 using only the standard library —
+    so the shipper needs neither boto3 nor uv. Virtual-hosted-style endpoint;
+    long-lived IAM user keys (no session token)."""
+    ak = creds["aws_access_key_id"]
+    sk = creds["aws_secret_access_key"]
+    host = f"{bucket}.s3.{region}.amazonaws.com"
+    canonical_uri = "/" + "/".join(urllib.parse.quote(seg, safe="") for seg in key.split("/"))
+    now = datetime.datetime.now(datetime.timezone.utc)
+    amzdate = now.strftime("%Y%m%dT%H%M%SZ")
+    datestamp = now.strftime("%Y%m%d")
+    payload_hash = hashlib.sha256(body).hexdigest()
+    canonical_headers = (f"host:{host}\n"
+                         f"x-amz-content-sha256:{payload_hash}\n"
+                         f"x-amz-date:{amzdate}\n")
+    signed_headers = "host;x-amz-content-sha256;x-amz-date"
+    canonical_request = (f"PUT\n{canonical_uri}\n\n{canonical_headers}\n"
+                         f"{signed_headers}\n{payload_hash}")
+    scope = f"{datestamp}/{region}/s3/aws4_request"
+    string_to_sign = (f"AWS4-HMAC-SHA256\n{amzdate}\n{scope}\n"
+                      f"{hashlib.sha256(canonical_request.encode()).hexdigest()}")
+
+    def _h(key_: bytes, msg: str) -> bytes:
+        return hmac.new(key_, msg.encode(), hashlib.sha256).digest()
+
+    k = _h(("AWS4" + sk).encode(), datestamp)
+    k = _h(k, region)
+    k = _h(k, "s3")
+    k = _h(k, "aws4_request")
+    signature = hmac.new(k, string_to_sign.encode(), hashlib.sha256).hexdigest()
+    authorization = (f"AWS4-HMAC-SHA256 Credential={ak}/{scope}, "
+                     f"SignedHeaders={signed_headers}, Signature={signature}")
+    req = urllib.request.Request(
+        f"https://{host}{canonical_uri}", data=body, method="PUT",
+        headers={
+            "x-amz-date": amzdate,
+            "x-amz-content-sha256": payload_hash,
+            "Authorization": authorization,
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=20, context=_ssl_context()) as r:
+        return 200 <= r.status < 300
+
+
+def _ssl_context() -> ssl.SSLContext:
+    """System default CA (works in Linux containers). If this Python has no usable
+    CA store (some macOS framework builds), fall back to certifi or a common CA
+    bundle path so the stdlib uploader can still verify TLS."""
+    ctx = ssl.create_default_context()
+    try:
+        if ctx.cert_store_stats().get("x509_ca", 0) > 0:
+            return ctx
+    except Exception:  # noqa: BLE001
+        return ctx
+    candidates = []
+    try:
+        import certifi  # noqa: PLC0415
+        candidates.append(certifi.where())
+    except Exception:  # noqa: BLE001
+        pass
+    candidates += [
+        "/etc/ssl/cert.pem", "/etc/ssl/certs/ca-certificates.crt",
+        "/etc/pki/tls/certs/ca-bundle.crt", "/usr/local/etc/openssl/cert.pem",
+    ]
+    for ca in candidates:
+        try:
+            if ca and Path(ca).is_file():
+                c = ssl.create_default_context(cafile=ca)
+                if c.cert_store_stats().get("x509_ca", 0) > 0:
+                    return c
+        except Exception:  # noqa: BLE001
+            continue
+    return ctx
+
+
+@contextlib.contextmanager
+def queue_lock():
+    RETRY_QUEUE.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = RETRY_QUEUE.with_suffix(".lock")
+    with lock_path.open("a+") as lf:
+        try:
+            fcntl.flock(lf.fileno(), fcntl.LOCK_EX)
+            yield
+        finally:
+            fcntl.flock(lf.fileno(), fcntl.LOCK_UN)
+
+
+def drain_retry_queue(bucket: str, prefix: str, region) -> None:
+    if not RETRY_QUEUE.exists():
+        return
+    with queue_lock():
+        try:
+            lines = [l for l in RETRY_QUEUE.read_text().splitlines() if l.strip()]
+        except OSError as e:
+            log(f"queue read error: {e}")
+            return
+        if not lines:
+            return
+        remaining: list[str] = []
+        for line in lines:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                log("dropping malformed queue line")
+                continue
+            if not ship_record(bucket, prefix, region, record, line):
+                remaining.append(line)
+        if remaining:
+            RETRY_QUEUE.write_text("\n".join(remaining) + "\n")
+            log(f"drain: {len(lines) - len(remaining)} ok, {len(remaining)} still queued")
+        else:
+            RETRY_QUEUE.unlink(missing_ok=True)
+            log(f"drain: all {len(lines)} flushed")
+
+
+def enqueue(line: str) -> None:
+    with queue_lock():
+        with RETRY_QUEUE.open("a") as f:
+            f.write(line.rstrip("\n") + "\n")
+
+
+def main() -> int:
+    cfg = load_config()
+    if cfg is None:
+        return 0  # S3 shipping disabled — no-op
+
+    payload = sys.argv[1] if len(sys.argv) > 1 else sys.stdin.read()
+    payload = payload.strip()
+
+    bucket = cfg["s3_bucket"]
+    prefix = cfg.get("s3_prefix", "sessions")
+    region = cfg.get("aws_region")
+
+    # No boto3 gate any more — _put signs with stdlib SigV4 when boto3 is absent,
+    # so a bare python3 ships fine and the retry queue actually drains.
+    drain_retry_queue(bucket, prefix, region)
+
+    if not payload:
+        return 0
+
+    try:
+        record = json.loads(payload)
+    except json.JSONDecodeError as e:
+        log(f"argv payload not JSON: {e}")
+        return 0
+
+    if not ship_record(bucket, prefix, region, record, payload):
+        enqueue(payload)
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:  # noqa: BLE001 — never propagate
+        log(f"fatal: {type(e).__name__}: {e}")
+        sys.exit(0)


### PR DESCRIPTION
Adds Claude Code session monitoring: vendors the runtime and wires the dev container so any container built from this repo auto-seeds the session hooks and a persistent log volume, and registers the session hooks for local sessions. The dashboard HTML and AWS credentials stay gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)